### PR TITLE
Add scale-reference grid under the 3D model (#20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-enclosure",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-enclosure",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "dependencies": {
         "@angular/common": "^20.3.0",
         "@angular/compiler": "^20.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-enclosure",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "private": true,
   "homepage": "https://bruceborrett.github.io/easy-enclosure/",
   "prettier": {

--- a/src/app/app-version.ts
+++ b/src/app/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '1.2.4';
+export const APP_VERSION = '1.3.0';

--- a/src/app/core/params.ts
+++ b/src/app/core/params.ts
@@ -42,6 +42,9 @@ export type Params = {
   insertClearance: number;
   showLid: boolean;
   showBase: boolean;
+  gridSpacing: number;
+  gridWidth: number;
+  gridLength: number;
   cornerRadius: number;
   holes: Hole[];
   pcbMounts: PCBMount[];
@@ -68,6 +71,9 @@ export const DEFAULT_PARAMS: Params = {
   insertClearance: 0.04,
   showLid: true,
   showBase: true,
+  gridSpacing: 10,
+  gridWidth: 320,
+  gridLength: 320,
   cornerRadius: 3,
   holes: [
     {

--- a/src/app/features/params/params-form.component.html
+++ b/src/app/features/params/params-form.component.html
@@ -499,4 +499,48 @@
       }
     </div>
   </div>
+
+  <div class="accordian" [class.active]="activeTab() === 9">
+    <p class="accordian-header" (click)="setActiveTab(9)">
+      Grid
+      <span class="accordian-icon">{{ activeTab() === 9 ? '-' : '+' }}</span>
+    </p>
+    <div class="accordian-body">
+      <div class="input-group">
+        <label>Grid Spacing (mm)</label>
+        <input
+          type="number"
+          min="0"
+          step="1"
+          [value]="params().gridSpacing"
+          (keydown.enter)="$any($event.target).blur()"
+          (blur)="setNumberParam('gridSpacing', $any($event.target).value)"
+        />
+        <small class="hint">Distance between lines. Set to 0 to hide the grid.</small>
+      </div>
+      <div class="input-group">
+        <label>Grid Width (mm)</label>
+        <input
+          type="number"
+          min="1"
+          step="1"
+          [value]="params().gridWidth"
+          (keydown.enter)="$any($event.target).blur()"
+          (blur)="setNumberParam('gridWidth', $any($event.target).value)"
+        />
+      </div>
+      <div class="input-group">
+        <label>Grid Length (mm)</label>
+        <input
+          type="number"
+          min="1"
+          step="1"
+          [value]="params().gridLength"
+          (keydown.enter)="$any($event.target).blur()"
+          (blur)="setNumberParam('gridLength', $any($event.target).value)"
+        />
+        <small class="hint">Grid fades out past 320 mm.</small>
+      </div>
+    </div>
+  </div>
 </form>

--- a/src/app/features/renderer/renderer.component.spec.ts
+++ b/src/app/features/renderer/renderer.component.spec.ts
@@ -1,5 +1,6 @@
 import { fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
 
+import { DEFAULT_PARAMS } from '../../core/params';
 import { EnclosureStateService } from '../../core/state/enclosure-state.service';
 import { RendererComponent } from './renderer.component';
 
@@ -36,4 +37,66 @@ describe('RendererComponent', () => {
     expect(renderModelSpy).toHaveBeenCalled();
     expect(localState.loading()).toBeFalse();
   }));
+
+  describe('buildGridEntity', () => {
+    it('returns null when gridSpacing is 0', () => {
+      const fixture = TestBed.createComponent(RendererComponent);
+      component = fixture.componentInstance;
+      const result = (component as any).buildGridEntity({
+        ...DEFAULT_PARAMS,
+        gridSpacing: 0,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('returns a drawGrid entity sized to gridWidth/gridLength', () => {
+      const fixture = TestBed.createComponent(RendererComponent);
+      component = fixture.componentInstance;
+      const result = (component as any).buildGridEntity({
+        ...DEFAULT_PARAMS,
+        gridSpacing: 10,
+        gridWidth: 200,
+        gridLength: 150,
+      });
+      expect(result).not.toBeNull();
+      expect(result.visuals.drawCmd).toBe('drawGrid');
+      expect(result.visuals.show).toBe(true);
+      // Rectangular extent [width, length].
+      expect(result.size).toEqual([200, 150]);
+      // ticks[1] = minor step = spacing; ticks[0] = major step = 5× spacing.
+      expect(result.ticks[1]).toBe(10);
+      expect(result.ticks[0]).toBe(50);
+    });
+
+    it('disables fadeOut while the grid is within 320 mm', () => {
+      const fixture = TestBed.createComponent(RendererComponent);
+      component = fixture.componentInstance;
+      const result = (component as any).buildGridEntity({
+        ...DEFAULT_PARAMS,
+        gridSpacing: 10,
+        gridWidth: 320,
+        gridLength: 320,
+      });
+      expect(result.visuals.fadeOut).toBe(false);
+    });
+
+    it('enables fadeOut once the grid exceeds 320 mm on either side', () => {
+      const fixture = TestBed.createComponent(RendererComponent);
+      component = fixture.componentInstance;
+      const wide = (component as any).buildGridEntity({
+        ...DEFAULT_PARAMS,
+        gridSpacing: 10,
+        gridWidth: 400,
+        gridLength: 320,
+      });
+      const long = (component as any).buildGridEntity({
+        ...DEFAULT_PARAMS,
+        gridSpacing: 10,
+        gridWidth: 320,
+        gridLength: 400,
+      });
+      expect(wide.visuals.fadeOut).toBe(true);
+      expect(long.visuals.fadeOut).toBe(true);
+    });
+  });
 });

--- a/src/app/features/renderer/renderer.component.ts
+++ b/src/app/features/renderer/renderer.component.ts
@@ -93,6 +93,7 @@ const mountDeps = [
   'insertClearance',
 ];
 const internalWallDeps = ['internalWalls', 'length', 'width', 'waterProof', 'floor'];
+const gridDeps = ['gridSpacing', 'gridWidth', 'gridLength'];
 
 type RenderOptions = {
   camera: typeof cameras.perspective.defaults;
@@ -269,6 +270,44 @@ export class RendererComponent implements AfterViewInit, OnDestroy {
     return diffKeys;
   }
 
+  /**
+   * Build a scale-reference grid under the model using the renderer's native
+   * `drawGrid` command — the same one OpenJSCAD's own viewer uses. It draws
+   * thin two-tier lines (major + sub-grid) with anti-z-fighting polygon offset,
+   * alpha blending, and optional fog fade-out, so there is no need to build a
+   * floor slab or line geometry by hand.
+   *
+   * - `gridSpacing` is the distance between minor lines in mm; 0 hides the grid.
+   * - `gridWidth` / `gridLength` are the grid extents in mm (X and Y), so the
+   *   grid can be rectangular.
+   * - Lines fade out toward the edges once the grid exceeds 320 mm on either
+   *   side, so large grids dissolve into the background instead of showing a
+   *   hard square boundary. Major lines fall every fifth spacing.
+   */
+  private buildGridEntity(params: Params): Entity | null {
+    const spacing = Math.max(0, params.gridSpacing);
+    if (spacing === 0) {
+      return null;
+    }
+
+    const width = Math.max(1, params.gridWidth);
+    const length = Math.max(1, params.gridLength);
+    const fadeOut = width > 320 || length > 320;
+
+    return {
+      visuals: {
+        drawCmd: 'drawGrid',
+        show: true,
+        color: [0, 0, 0, 1],
+        subColor: [0, 0, 1, 0.5],
+        fadeOut,
+        transparent: true,
+      },
+      size: [width, length],
+      ticks: [spacing * 5, spacing],
+    } as unknown as Entity;
+  }
+
   private scheduleModelRender(params: Params): void {
     if (!this.isViewReady) {
       return;
@@ -334,10 +373,14 @@ export class RendererComponent implements AfterViewInit, OnDestroy {
         return;
       }
       this.control.zoomToFit.tightness = 1;
+      // Frame the model only: reference entities (drawGrid/drawAxis) carry no
+      // `geometry`, so including them would feed `undefined` into the bounds
+      // calculation and NaN out the camera.
+      const frameEntities = this.renderOptions.entities.filter((entity) => entity.geometry);
       const updated = this.orbitControls.zoomToFit({
         controls: this.control,
         camera: this.camera,
-        entities: this.renderOptions.entities,
+        entities: frameEntities,
       });
       this.control = { ...this.control, ...updated.controls };
       this.zoomToFit = false;
@@ -640,10 +683,23 @@ export class RendererComponent implements AfterViewInit, OnDestroy {
 
     this.model = union(result);
 
+    const modelEntities = entitiesFromSolids({}, this.model) as Entity[];
+    const gridEntity = this.buildGridEntity(params);
+    // The grid is a reference plane sitting under the model, so list it first
+    // so it draws before the solid geometry.
+    const entities: Entity[] = gridEntity ? [gridEntity, ...modelEntities] : modelEntities;
+
+    // Re-frame the camera when the grid becomes visible (so it lands in view)
+    // or when its size-affecting inputs change while it is on. Leave the user's
+    // manual orbit alone when the grid is simply toggled off.
+    if (gridEntity && this.checkDeps(diff, gridDeps)) {
+      this.zoomToFit = true;
+    }
+
     this.renderOptions = {
       camera: this.camera,
       drawCommands,
-      entities: entitiesFromSolids({}, this.model) as Entity[],
+      entities,
     };
 
     if (!this.renderer && this.containerRef?.nativeElement) {
@@ -656,7 +712,7 @@ export class RendererComponent implements AfterViewInit, OnDestroy {
         this.updateAndRender();
       }
     } else {
-      this.renderOptions.entities = entitiesFromSolids({}, this.model) as Entity[];
+      this.renderOptions.entities = entities;
       this.updateView = true;
       this.updateSurfaceLabels();
     }


### PR DESCRIPTION
close #20 
Render a scale-reference grid beneath the enclosure using the renderer's native `drawGrid` command from @jscad/regl-renderer — the same command OpenJSCAD's own viewer uses — instead of hand-built floor/line geometry.

A new "Grid" accordion exposes:
- Grid Spacing (mm): distance between lines; 0 hides the grid.
- Grid Width / Grid Length (mm): rectangular grid extent. Lines fade out toward the edges once the grid exceeds 320 mm — roughly the build area of a typical home FDM printer (Bambu Lab and the like), so a grid that fits on a single print bed stays crisp while anything larger dissolves into the background without a hard boundary.

Bumps version to 1.3.0.

Coded with AI