### PR TITLE
feat: add DIN rail (TH35) mount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pull requests are also welcome!
 - [x] PCB Mounts
 - [x] Export each entity seperately
 - [x] Save settings to file
-- [ ] Din rail mounts
+- [x] Din rail mounts
 - [ ] Pre-defined templates for common devices (Pi, Arduino etc)
 
 ## Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-enclosure",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-enclosure",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@angular/common": "^20.3.0",
         "@angular/compiler": "^20.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-enclosure",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "homepage": "https://bruceborrett.github.io/easy-enclosure/",
   "prettier": {

--- a/src/app/app-version.ts
+++ b/src/app/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '1.2.4';
+export const APP_VERSION = '1.2.5';

--- a/src/app/core/enclosure/base.ts
+++ b/src/app/core/enclosure/base.ts
@@ -6,6 +6,7 @@ import { flanges } from './wallmount';
 import { clover, hollowRoundCube, roundedCube } from './utils';
 import { waterProofSealCutout } from './waterproofseal';
 import { screws } from './screws';
+import { dinRailMount } from './dinrail';
 import { translate } from '@jscad/modeling/src/operations/transforms';
 
 const { subtract, union } = booleans;
@@ -56,6 +57,10 @@ export const base = (params: Params) => {
 
   if (params.wallMounts) {
     body.push(flanges(params));
+  }
+
+  if (params.dinRailMount) {
+    body.push(dinRailMount(params));
   }
 
   if (params.waterProof) {

--- a/src/app/core/enclosure/dinrail.spec.ts
+++ b/src/app/core/enclosure/dinrail.spec.ts
@@ -1,0 +1,111 @@
+import measureBoundingBox from '@jscad/modeling/src/measurements/measureBoundingBox';
+import measureVolume from '@jscad/modeling/src/measurements/measureVolume';
+import { intersect } from '@jscad/modeling/src/operations/booleans';
+import { cuboid } from '@jscad/modeling/src/primitives';
+
+import { DEFAULT_PARAMS, cloneParams } from '../params';
+import { base } from './base';
+import { dinRailChannel, dinRailMount } from './dinrail';
+
+describe('dinRailMount', () => {
+  it('is disabled by default with TH35 defaults', () => {
+    expect(DEFAULT_PARAMS.dinRailMount).toBe(false);
+    expect(DEFAULT_PARAMS.dinRailSurface).toBe('bottom');
+    expect(DEFAULT_PARAMS.dinRailWidth).toBe(35);
+    expect(DEFAULT_PARAMS.dinRailCrownWidth).toBe(27);
+    expect(DEFAULT_PARAMS.dinRailDepth).toBe(8.5);
+    expect(DEFAULT_PARAMS.dinRailLength).toBe(60);
+  });
+
+  it('protrudes below the floor only when enabled (default behaviour unchanged)', () => {
+    const off = measureBoundingBox(base(DEFAULT_PARAMS));
+    const onParams = cloneParams(DEFAULT_PARAMS);
+    onParams.dinRailMount = true;
+    const on = measureBoundingBox(base(onParams));
+
+    expect(off[0][2]).toBeGreaterThanOrEqual(-0.001); // nothing below the floor by default
+    expect(on[0][2]).toBeLessThan(-5); // DIN boss sticks out below the floor
+    expect(on[0][2]).toBeLessThan(off[0][2]);
+  });
+
+  it('places the bottom mount flush on the floor and within the footprint', () => {
+    const params = cloneParams(DEFAULT_PARAMS);
+    params.dinRailMount = true;
+    params.dinRailSurface = 'bottom';
+    const [[xMin, yMin, zMin], [xMax, yMax, zMax]] = measureBoundingBox(dinRailMount(params));
+
+    expect(zMin).toBeLessThan(0);
+    expect(zMax).toBeCloseTo(0, 5);
+    expect(xMin).toBeGreaterThanOrEqual(0);
+    expect(xMax).toBeLessThanOrEqual(params.width);
+    expect(yMin).toBeGreaterThanOrEqual(0);
+    expect(yMax).toBeLessThanOrEqual(params.length);
+  });
+
+  it('places the back mount behind the back wall', () => {
+    const params = cloneParams(DEFAULT_PARAMS);
+    params.dinRailMount = true;
+    params.dinRailSurface = 'back';
+    params.height = 50; // must exceed dinRailWidth + 2 * MARGIN (39) to avoid overhang
+    const [[, yMin]] = measureBoundingBox(dinRailMount(params));
+
+    expect(yMin).toBeLessThan(0);
+  });
+
+  it('cuts a real top-hat slot out of the boss', () => {
+    const params = cloneParams(DEFAULT_PARAMS);
+    params.dinRailMount = true;
+    const slotted = dinRailMount(params);
+
+    const MARGIN = 2;
+    const bossAcrossRail = params.dinRailWidth + 2 * MARGIN;
+    const bossThickness = params.dinRailDepth + MARGIN;
+    const solid = cuboid({
+      center: [0, 0, -bossThickness / 2],
+      size: [params.dinRailLength, bossAcrossRail, bossThickness],
+    });
+
+    expect(measureVolume(slotted)).toBeLessThan(measureVolume(solid));
+    expect(measureVolume(solid) - measureVolume(slotted)).toBeGreaterThan(1000);
+  });
+
+  it('can coexist with wall mounts on the same enclosure', () => {
+    const params = cloneParams(DEFAULT_PARAMS);
+    params.wallMounts = true;
+    params.dinRailMount = true;
+    params.dinRailSurface = 'bottom';
+    const [[xMin, , zMin], [xMax]] = measureBoundingBox(base(params));
+
+    // wall flanges protrude beyond the left/right walls...
+    expect(xMin).toBeLessThan(0);
+    expect(xMax).toBeGreaterThan(params.width);
+    // ...while the DIN boss protrudes below the floor
+    expect(zMin).toBeLessThan(0);
+  });
+
+  it('forms an undercut that retains the rail (mouth narrower than the brim chamber)', () => {
+    const params = cloneParams(DEFAULT_PARAMS);
+    params.dinRailMount = true;
+    const channel = dinRailChannel(params);
+
+    const MARGIN = 2; // mirrors the module constant
+    const SLOT_DEPTH_CLEARANCE = 0.4; // mirrors the module constant
+    const bossThickness = params.dinRailDepth + MARGIN;
+    const slotDepth = params.dinRailDepth + SLOT_DEPTH_CLEARANCE;
+
+    const widthAt = (z: number) => {
+      const slice = intersect(
+        channel,
+        cuboid({ center: [0, 0, z], size: [params.dinRailLength + 20, 200, 0.05] }),
+      );
+      const [[, yMin], [, yMax]] = measureBoundingBox(slice);
+      return yMax - yMin;
+    };
+
+    const mouthWidth = widthAt(-bossThickness + 0.15); // just inside the outer face
+    const chamberWidth = widthAt(-bossThickness + slotDepth - 0.15); // just inside the deep chamber
+
+    expect(mouthWidth).toBeLessThan(params.dinRailWidth); // brim (35) cannot pass back out
+    expect(chamberWidth - mouthWidth).toBeGreaterThan(4); // meaningful undercut → rail retained
+  });
+});

--- a/src/app/core/enclosure/dinrail.ts
+++ b/src/app/core/enclosure/dinrail.ts
@@ -1,0 +1,82 @@
+import { Geom3 } from '@jscad/modeling/src/geometries/types';
+import { subtract } from '@jscad/modeling/src/operations/booleans';
+import { hull } from '@jscad/modeling/src/operations/hulls';
+import { rotateX, translate } from '@jscad/modeling/src/operations/transforms';
+import { cuboid } from '@jscad/modeling/src/primitives';
+import { degToRad } from '@jscad/modeling/src/utils';
+
+import { Params } from '../params';
+
+const MARGIN = 2; // boss material around/behind the slot (also keeps the interior intact)
+const SLOT_DEPTH_CLEARANCE = 0.4; // vertical play so the rail slides/snaps
+const SLOT_WIDTH_CLEARANCE = 0.5; // horizontal play on brim & crown
+const HULL_EPSILON = 0.1; // thin slab thickness; over-extends ends so the slot breaks through
+
+/**
+ * The top-hat slot cutter (a trapezoidal prism along the rail axis X), built in
+ * canonical orientation where the slot mouth faces -Z (outward) and the closed
+ * chamber sits deeper (toward +Z / the enclosure wall).
+ *
+ * It is an UNDERCUT: the mouth is narrow (= dinRailCrownWidth, so the rail's
+ * crown passes through) and it widens inward to a chamber (= dinRailWidth,
+ * which holds the rail's wider base/brim). The brim cannot pass back through
+ * the narrower mouth, so the rail is retained (snap-in fit).
+ */
+export const dinRailChannel = (params: Params): Geom3 => {
+  const { dinRailWidth, dinRailCrownWidth, dinRailDepth, dinRailLength } = params;
+
+  const slotDepth = dinRailDepth + SLOT_DEPTH_CLEARANCE;
+  const bossThickness = dinRailDepth + MARGIN;
+  const mouthZ = -bossThickness; // outer face — narrow throat
+  const chamberZ = mouthZ + slotDepth; // deep — wide brim chamber
+  const len = dinRailLength + 2 * HULL_EPSILON; // over-extend so both ends cut open
+
+  return hull(
+    cuboid({
+      center: [0, 0, mouthZ],
+      size: [len, dinRailCrownWidth + SLOT_WIDTH_CLEARANCE, HULL_EPSILON],
+    }),
+    cuboid({
+      center: [0, 0, chamberZ],
+      size: [len, dinRailWidth + SLOT_WIDTH_CLEARANCE, HULL_EPSILON],
+    }),
+  );
+};
+
+/**
+ * Boss with the top-hat slot carved through it, built in canonical orientation:
+ * the slot mouth faces -Z (outward), the flush face sits at z = 0, the channel
+ * runs along X (rail axis) and the rail width spans Y.
+ */
+const dinBoss = (params: Params): Geom3 => {
+  const { dinRailWidth, dinRailDepth, dinRailLength } = params;
+
+  const bossAcrossRail = dinRailWidth + 2 * MARGIN; // Y — fits the brim chamber + walls
+  const bossThickness = dinRailDepth + MARGIN; // Z (material behind the chamber >= MARGIN)
+
+  const boss = cuboid({
+    center: [0, 0, -bossThickness / 2],
+    size: [dinRailLength, bossAcrossRail, bossThickness],
+  });
+
+  return subtract(boss, dinRailChannel(params));
+};
+
+/**
+ * DIN rail (TH35) mount: a slotted boss placed on the chosen face so a standard
+ * 35 mm top-hat rail snaps in and is retained by the undercut mouth. `bottom`
+ * protrudes below the floor; `back` protrudes behind the back wall (needs
+ * height >= dinRailWidth + 2 * MARGIN).
+ */
+export const dinRailMount = (params: Params): Geom3 => {
+  const { width, length, height } = params;
+  const boss = dinBoss(params);
+
+  if (params.dinRailSurface === 'back') {
+    // rotateX(-90) maps the canonical outward (-Z) onto the back wall's outward (-Y).
+    return translate([width / 2, 0, height / 2], rotateX(degToRad(-90), boss));
+  }
+
+  // 'bottom' (default): canonical outward (-Z) is already the floor's outward direction.
+  return translate([width / 2, length / 2, 0], boss);
+};

--- a/src/app/core/params.ts
+++ b/src/app/core/params.ts
@@ -52,6 +52,12 @@ export type Params = {
   lidScrews: boolean;
   lidScrewDiameter: number;
   baseLidScrewDiameter: number;
+  dinRailMount: boolean;
+  dinRailSurface: 'bottom' | 'back';
+  dinRailWidth: number;
+  dinRailCrownWidth: number;
+  dinRailDepth: number;
+  dinRailLength: number;
 };
 
 export const DEFAULT_PARAMS: Params = {
@@ -166,6 +172,12 @@ export const DEFAULT_PARAMS: Params = {
   lidScrews: true,
   lidScrewDiameter: 2.98,
   baseLidScrewDiameter: 2.88,
+  dinRailMount: false,
+  dinRailSurface: 'bottom',
+  dinRailWidth: 35,
+  dinRailCrownWidth: 27,
+  dinRailDepth: 8.5,
+  dinRailLength: 60,
 };
 
 export const cloneParams = (params: Params): Params => {

--- a/src/app/core/state/enclosure-state.service.ts
+++ b/src/app/core/state/enclosure-state.service.ts
@@ -46,6 +46,7 @@ export class EnclosureStateService {
       waterProof: false,
       wallMounts: false,
       lidScrews: false,
+      dinRailMount: false,
     }));
   }
 }

--- a/src/app/features/params/params-form.component.css
+++ b/src/app/features/params/params-form.component.css
@@ -92,6 +92,12 @@ label {
   vertical-align: top;
 }
 
+/* A toggle (checkbox) gets its own full-width row so it doesn't share a line
+   with the parameter fields below/beside it. */
+.input-group:has(input[type='checkbox']) {
+  width: 100%;
+}
+
 .compact-params {
   padding: 2px 0;
 }

--- a/src/app/features/params/params-form.component.html
+++ b/src/app/features/params/params-form.component.html
@@ -460,7 +460,7 @@
 
   <div class="accordian" [class.active]="activeTab() === 8">
     <p class="accordian-header" (click)="setActiveTab(8)">
-      Wall Mounts
+      Mounting
       <span class="accordian-icon">{{ activeTab() === 8 ? '-' : '+' }}</span>
     </p>
     <div class="accordian-body">
@@ -494,6 +494,76 @@
             [value]="params().wallMountScrewDiameter"
             (keydown.enter)="$any($event.target).blur()"
             (blur)="setNumberParam('wallMountScrewDiameter', $any($event.target).value)"
+          />
+        </div>
+      }
+
+      <div class="input-group">
+        <label>DIN Rail Mount</label>
+        <input
+          type="checkbox"
+          [checked]="params().dinRailMount"
+          (change)="setBooleanParam('dinRailMount', $any($event.target).checked)"
+        />
+      </div>
+
+      @if (params().dinRailMount) {
+        <div class="input-group">
+          <label>Surface</label>
+          <select
+            [value]="params().dinRailSurface"
+            (change)="setDinRailSurface($any($event.target).value)"
+          >
+            <option value="bottom">Bottom</option>
+            <option value="back">Back</option>
+          </select>
+        </div>
+
+        <div class="input-group">
+          <label>Rail Width</label>
+          <input
+            type="number"
+            min="20"
+            step="0.1"
+            [value]="params().dinRailWidth"
+            (keydown.enter)="$any($event.target).blur()"
+            (blur)="setNumberParam('dinRailWidth', $any($event.target).value)"
+          />
+        </div>
+
+        <div class="input-group">
+          <label>Crown Width</label>
+          <input
+            type="number"
+            min="15"
+            step="0.1"
+            [value]="params().dinRailCrownWidth"
+            (keydown.enter)="$any($event.target).blur()"
+            (blur)="setNumberParam('dinRailCrownWidth', $any($event.target).value)"
+          />
+        </div>
+
+        <div class="input-group">
+          <label>Rail Depth</label>
+          <input
+            type="number"
+            min="5"
+            step="0.1"
+            [value]="params().dinRailDepth"
+            (keydown.enter)="$any($event.target).blur()"
+            (blur)="setNumberParam('dinRailDepth', $any($event.target).value)"
+          />
+        </div>
+
+        <div class="input-group">
+          <label>Slot Length</label>
+          <input
+            type="number"
+            min="20"
+            step="1"
+            [value]="params().dinRailLength"
+            (keydown.enter)="$any($event.target).blur()"
+            (blur)="setNumberParam('dinRailLength', $any($event.target).value)"
           />
         </div>
       }

--- a/src/app/features/params/params-form.component.ts
+++ b/src/app/features/params/params-form.component.ts
@@ -144,6 +144,12 @@ export class ParamsFormComponent {
     });
   }
 
+  setDinRailSurface(value: string): void {
+    if (value === 'bottom' || value === 'back') {
+      this.state.updateParam('dinRailSurface', value);
+    }
+  }
+
   parseIntValue(rawValue: string): number {
     return parseInt(rawValue, 10);
   }

--- a/src/app/features/renderer/renderer.component.ts
+++ b/src/app/features/renderer/renderer.component.ts
@@ -65,6 +65,12 @@ const baseDeps = [
   'wallMountScrewDiameter',
   'wallMountCount',
   'insertClearance',
+  'dinRailMount',
+  'dinRailSurface',
+  'dinRailWidth',
+  'dinRailCrownWidth',
+  'dinRailDepth',
+  'dinRailLength',
 ];
 const sealDeps = [
   'length',


### PR DESCRIPTION
## Summary

Closes #37

Adds a parametric TH35 top-hat rail mount as a **second, independent toggle** inside the existing Wall Mounts section (renamed to **Mounting**). The mount is a slotted boss that protrudes from the chosen enclosure face with a trapezoidal **undercut** channel cut through it, so a standard 35 mm top-hat rail slides in end-on and is retained by the narrower mouth.

The existing `wallMounts` flag is left untouched — wall flanges and the DIN boss are **independent** and can be active simultaneously.

## What is new

- `src/app/core/enclosure/dinrail.ts` — new geometry module (channel + boss + placement).
- `src/app/core/enclosure/dinrail.spec.ts` — 7 Jasmine specs covering defaults, protrusion, placement (`bottom`/`back`), channel cuts volume, coexistence with wall mounts, and undercut retention.
- `src/app/core/params.ts` — 6 new params (`dinRailMount`, `dinRailSurface`, `dinRailWidth`, `dinRailCrownWidth`, `dinRailDepth`, `dinRailLength`) + TH35 defaults.
- `src/app/core/enclosure/base.ts` — extra `if (params.dinRailMount)` branch alongside the existing `wallMounts` branch.
- `src/app/features/renderer/renderer.component.ts` — the 6 DIN params added to `baseDeps`.
- `src/app/features/params/params-form.component.{html,ts,css}` — accordion renamed to **Mounting**; new DIN toggle group (`Surface` select, `Rail Width`, `Crown Width`, `Rail Depth`, `Slot Length` number inputs); checkboxes forced onto their own full-width row.
- `src/app/core/state/enclosure-state.service.ts` — `resetToSimpleEnclosure` now also resets `dinRailMount`.
- `README.md` — feature ticked off.

## Design notes

- **TH35 defaults**: brim/base width `35`, crown/top width `27`, height `8.5`. All four numbers are exposed as user inputs for non-TH35 rails (TH35-15, asymmetric rails, etc.).
- **Mechanism**: rail slides in end-on; no spring/snap. Channel cross-section is built as `hull(two thin Z-slabs)` — the same idiom already used by `wallmount.ts` and `utils.ts: roundedCube`.
- **Retention via undercut**: mouth width = `crown + clearance` (27.5), chamber width = `brim + clearance` (35.5). The wider brim cannot pass back through the narrower mouth — a snap-in fit.
- **Placement**: `bottom` (default) and `back`. Each mode has its own translate/rotate so the channel exits to the correct face.
- **Independent of wallMounts**: flanges live on the left/right walls; the DIN boss lives on the bottom (or back) face — no geometric overlap.
- **Defaults preserved**: `wallMounts` stays at its current default; `dinRailMount` is opt-in (off by default) per the issue acceptance criteria.

## Verification

- `npm test` → **28/28 SUCCESS** (7 new + 21 existing).
- `npm start` → toggling Wall and DIN Rail independently and together in the **Mounting** accordion updates the live preview; switching `Surface` (with `Height ≥ ~39` for Back) re-renders correctly; tweaking Rail Width / Crown Width / Depth / Length updates the slot.
- `npm run format` (prettier) — clean.
- `npm run build` — clean.

Coded with AI