### PR TITLE
Fix Hole/PCB Mount Surface dropdown showing wrong selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-enclosure",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-enclosure",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@angular/common": "^20.3.0",
         "@angular/compiler": "^20.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-enclosure",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "homepage": "https://bruceborrett.github.io/easy-enclosure/",
   "prettier": {

--- a/src/app/app-version.ts
+++ b/src/app/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '1.3.3';
+export const APP_VERSION = '1.3.4';

--- a/src/app/features/params/params-form.component.html
+++ b/src/app/features/params/params-form.component.html
@@ -156,7 +156,7 @@
               (change)="updateHole($index, { surface: $any($event.target).value })"
             >
               @for (surface of surfaces; track surface) {
-                <option [value]="surface">
+                <option [value]="surface" [selected]="surface === hole.surface">
                   {{ surfaceLabel(surface) }}
                 </option>
               }
@@ -245,7 +245,7 @@
               (change)="updatePcbMount($index, { surface: $any($event.target).value })"
             >
               @for (surface of surfaces; track surface) {
-                <option [value]="surface">
+                <option [value]="surface" [selected]="surface === (mount.surface || 'bottom')">
                   {{ surfaceLabel(surface) }}
                 </option>
               }


### PR DESCRIPTION
## Summary
- The Surface `<select>` for each Hole and PCB Mount (Params form) only bound `[value]` on the `<select>` itself, with its `<option>`s generated by a nested `@for`. Native `<select>` elements resolve `[value]` against their `<option>` children at binding time, which races against Angular creating those dynamically-generated options — so the browser silently falls back to selecting the first option ("Front") regardless of the hole/mount's actual `surface` value.
- The underlying params and 3D geometry were always correct (each default hole is genuinely on a different face — front/left/back/right/top), it was purely the dropdown's displayed selection that was wrong, which made it look like every hole was on the Front face.
- Fix: each `<option>` now sets `[selected]` explicitly based on the current value, which Angular applies per-option as it's created and keeps in sync afterwards — the standard fix for this well-known native-select-with-dynamic-options timing issue.

## Test plan
- [x] `npm run dev`, expanded Holes panel on load: Hole 1/2/3/4/5 dropdowns now correctly show Front/Left/Back/Right/Lid matching `DEFAULT_PARAMS`, instead of all showing "Front"
- [x] Changed a hole's surface via the dropdown and confirmed the 3D preview updates and the dropdown keeps the newly selected value
- [x] Same fix applied to the PCB Mounts Surface dropdown, which had the identical pattern/bug

cc @tyeth for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)